### PR TITLE
removed the -lcurses flag for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS_OSX = -lusb-1.0 -lobjc -framework CoreFoundation -framework IOKit -lreadline
-CFLAGS_LNX = -lusb-1.0 -lreadline -lcurses
+CFLAGS_LNX = -lusb-1.0 -lreadline
 CFLAGS_WIN = -lusb-1.0 -lreadline
 
 all:


### PR DESCRIPTION
removed the -lcurse flag for linux which is useless and causing problems for peoples who don't have lcurses
